### PR TITLE
fix: history-extraction correctness (rename lineage, committer dates, PR base branch)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,6 +57,13 @@ Use `\:` to escape literal colons in paths. Empty string or `.` means root.
 | `-o <options>` | Custom git rebase options |
 | `-i` | Interactive rebase mode |
 
+By default the rebase preserves each commit's original authorship date as its
+committer date (`--committer-date-is-author-date`), so an extracted history keeps
+its original timeline instead of collapsing to the moment gitmux ran (GitHub
+orders and groups commits by committer date). Set the
+`PRESERVE_COMMITTER_DATES=false` environment variable to use git's default
+(committer date = now).
+
 See [Rebase Strategies]({% link rebase-strategies.md %}) for detailed guidance.
 
 ## GitHub Integration

--- a/gitmux.sh
+++ b/gitmux.sh
@@ -422,6 +422,13 @@ GITMUX_FILTER_BACKEND="${GITMUX_FILTER_BACKEND:-auto}"
 # Don't default these rebase options *yet*
 MERGE_STRATEGY_OPTION_FOR_REBASE="${MERGE_STRATEGY_OPTION_FOR_REBASE:-theirs}"
 REBASE_OPTIONS="${REBASE_OPTIONS:-}"
+# When true (the default), the rebase step preserves each commit's original
+# authorship date as its committer date. Without it, `git rebase` stamps every
+# replayed commit with the current time, collapsing an extracted history into a
+# single timestamp and breaking GitHub's commit timeline (GitHub orders and
+# groups commits by committer date). Set PRESERVE_COMMITTER_DATES=false to keep
+# git's default (committer date = now).
+PRESERVE_COMMITTER_DATES="${PRESERVE_COMMITTER_DATES:-true}"
 GH_HOST="${GH_HOST:-github.com}"
 GITHUB_TEAMS=()
 PATH_MAPPINGS=()
@@ -2389,16 +2396,27 @@ fi
 
 MAX_RETRIES=50
 
+# Emit the `git rebase` flag that preserves original authorship dates as commit
+# (committer) dates, or nothing when the caller opts out via
+# PRESERVE_COMMITTER_DATES=false. Compatible with the merge/rebase backend used
+# below on modern git. See the PRESERVE_COMMITTER_DATES default above.
+function committer_date_rebase_flag () {
+  if [[ "${PRESERVE_COMMITTER_DATES:-true}" != "false" ]]; then
+    printf '%s' '--committer-date-is-author-date'
+  fi
+}
+
 # Rebase filtered content onto destination branch.
 # Handles interactive rebase, automatic conflict resolution, and retry logic.
 # Uses REBASE_OPTIONS global variable for rebase strategy.
 perform_rebase () {
  git config --worktree merge.renameLimit 999999999
  log "Rebase options --> ' ${REBASE_OPTIONS} '"
+ local _date_flag; _date_flag="$(committer_date_rebase_flag)"
  # shellcheck disable=SC2086
   if [[ $(echo " ${REBASE_OPTIONS} " | sed -E 's/.*(\ -i\ |\ --interactive\ ).*/INTERACTIVE/') == "INTERACTIVE" ]]; then
     log_info "🎛️  Interactive rebase detected."
-    if ! git rebase "${REBASE_OPTIONS}" "destination/${destination_branch}"; then
+    if ! git rebase ${_date_flag} "${REBASE_OPTIONS}" "destination/${destination_branch}"; then
       log_error "Interactive rebase failed or was aborted."
       log_info "📂 Navigate to the temp workspace to resolve manually:"
       log_info "   cd ${_WORKSPACE}"
@@ -2409,7 +2427,7 @@ perform_rebase () {
     log_info "   git push destination ${DESTINATION_PR_BRANCH_NAME}"
     log_info "📂 Navigate to the temp workspace to complete the workflow:"
     log_info "   cd ${_WORKSPACE}"
-  elif ! output="$(git rebase ${REBASE_OPTIONS} "destination/${destination_branch}" 2>&1)"; then
+  elif ! output="$(git rebase ${_date_flag} ${REBASE_OPTIONS} "destination/${destination_branch}" 2>&1)"; then
     # Handle rebase failures: check for common error patterns and attempt recovery
     if [[ "${output}" =~ "invalid upstream" ]]; then
       log_error "${output}"

--- a/gitmux.sh
+++ b/gitmux.sh
@@ -517,17 +517,23 @@ function parse_path_mapping () {
 # Validate that destination paths don't overlap.
 # Two paths overlap if one is a prefix of the other.
 # Arguments:
-#   $@ - Array of destination paths to check
+#   $@ - Array of destination paths to check. Each element may optionally be
+#        a "source<US>dest" pair (US = \x1f); when two mappings share a
+#        destination but have distinct sources, that is allowed with a
+#        warning (rename lineage: temporally disjoint source paths).
 # Returns:
 #   0 if no overlaps, 1 if overlaps detected
 function validate_no_dest_overlap () {
   local -a paths=("$@")
-  local i j path1 path2
+  local i j src1 src2 path1 path2
+  local _sep=$'\x1f'
 
   for ((i = 0; i < ${#paths[@]}; i++)); do
     for ((j = i + 1; j < ${#paths[@]}; j++)); do
-      path1="${paths[i]}"
-      path2="${paths[j]}"
+      src1="${paths[i]%%"$_sep"*}"
+      path1="${paths[i]#*"$_sep"}"
+      src2="${paths[j]%%"$_sep"*}"
+      path2="${paths[j]#*"$_sep"}"
 
       # Empty paths (root) overlap with everything
       if [[ -z "$path1" ]] || [[ -z "$path2" ]]; then
@@ -539,6 +545,10 @@ function validate_no_dest_overlap () {
 
       # Check if paths are identical
       if [[ "$path1" == "$path2" ]]; then
+        if [[ "$src1" != "$src2" ]]; then
+          log_warn "Duplicate destination '$path1' from distinct sources ('$src1', '$src2') — assuming temporally disjoint paths (rename lineage)"
+          continue
+        fi
         log_error "Destination path conflict: '$path1' specified multiple times"
         return 1
       fi
@@ -767,10 +777,16 @@ if [[ ${#PATH_MAPPINGS[@]} -gt 0 ]]; then
     _parsed_dests+=("$PARSED_DEST")
   done
 
-  # Validate no destination overlaps
-  if ! validate_no_dest_overlap "${_parsed_dests[@]}"; then
+  # Validate no destination overlaps (pass source<US>dest pairs so duplicate
+  # destinations from distinct sources can be allowed as rename lineage)
+  declare -a _parsed_pairs=()
+  for ((i = 0; i < ${#_parsed_dests[@]}; i++)); do
+    _parsed_pairs+=("${_parsed_sources[i]}"$'\x1f'"${_parsed_dests[i]}")
+  done
+  if ! validate_no_dest_overlap "${_parsed_pairs[@]}"; then
     errxit "Path mapping validation failed"
   fi
+  unset _parsed_pairs
 
   log "Parsed ${#PATH_MAPPINGS[@]} path mapping(s):"
   for ((i = 0; i < ${#_parsed_sources[@]}; i++)); do

--- a/gitmux.sh
+++ b/gitmux.sh
@@ -2584,7 +2584,7 @@ PR_DESCRIPTION=$(printf "%s\n" \
   "## Destination repository details" \
   "Destination URL: [\`${_canonical_destination_https_url}\`](${_canonical_destination_https_url})" \
   "PR Branch at Destination (head): \`${DESTINATION_PR_BRANCH_NAME}\`" \
-  "Destination branch (base): \`${DESTINATION_BRANCH}\`" \
+  "Destination branch (base): \`${destination_branch}\`" \
   "" \
   "------------------------------" \
 )

--- a/tests/test_gitmux_unit.bats
+++ b/tests/test_gitmux_unit.bats
@@ -663,6 +663,7 @@ HELPER_HEADER
         sed -n '/^function normalize_path () {/,/^}/p' "${GITMUX_SCRIPT}"
         sed -n '/^function parse_path_mapping () {/,/^}/p' "${GITMUX_SCRIPT}"
         sed -n '/^function validate_no_dest_overlap () {/,/^}/p' "${GITMUX_SCRIPT}"
+        sed -n '/^function committer_date_rebase_flag () {/,/^}/p' "${GITMUX_SCRIPT}"
     } >> "${MULTIPATH_HELPER}"
 
     source "${MULTIPATH_HELPER}"
@@ -1825,4 +1826,119 @@ Generated with [Some Tool](https://example.com)"
     local us=$'\x1f'
     run validate_no_dest_overlap "a/x${us}lib" "b/y${us}lib/utils"
     [[ "$status" -ne 0 ]]
+}
+
+# =============================================================================
+# Committer-date preservation flag. Default-on so an extracted history keeps its
+# original timeline; opt out with PRESERVE_COMMITTER_DATES=false.
+# =============================================================================
+
+@test "committer_date_rebase_flag: enabled by default (unset)" {
+    setup_multipath_helpers
+    local out
+    out="$(unset PRESERVE_COMMITTER_DATES; committer_date_rebase_flag)"
+    [[ "$out" == "--committer-date-is-author-date" ]]
+}
+
+@test "committer_date_rebase_flag: enabled when explicitly true" {
+    setup_multipath_helpers
+    local out
+    out="$(PRESERVE_COMMITTER_DATES=true committer_date_rebase_flag)"
+    [[ "$out" == "--committer-date-is-author-date" ]]
+}
+
+@test "committer_date_rebase_flag: emits nothing when opted out" {
+    setup_multipath_helpers
+    local out
+    out="$(PRESERVE_COMMITTER_DATES=false committer_date_rebase_flag)"
+    [[ -z "$out" ]]
+}
+
+# =============================================================================
+# End-to-end: the rebase onto the destination must preserve each commit's
+# original date rather than stamping it with 'now'. Paired opt-in/opt-out runs
+# isolate the flag as the cause (guards against a false pass).
+# =============================================================================
+
+@test "e2e: rebase preserves original commit date by default" {
+    setup_local_repos
+
+    # Source commit with an OLD author date but a recent committer date. Without
+    # --committer-date-is-author-date the rebase would stamp the replayed commit
+    # with 'now', discarding 2019 and collapsing the timeline on GitHub.
+    cd "$E2E_TEST_DIR/source" || return 1
+    echo "content" > file.txt
+    git add .
+    GIT_AUTHOR_DATE="2019-06-15T12:00:00-05:00" \
+    GIT_COMMITTER_DATE="2026-01-02T03:04:05-05:00" \
+        git commit -m "Old authored work"
+    git push origin main
+
+    # Default run: PRESERVE_COMMITTER_DATES defaults to true.
+    cd "$BATS_TEST_DIRNAME/.." || return 1
+    run bash -c "./gitmux.sh \
+        -r '$E2E_TEST_DIR/source' \
+        -t '$E2E_TEST_DIR/dest' \
+        -b main \
+        -k <<< 'y' 2>&1"
+    echo "gitmux output: $output" >&2
+    [[ ! "$output" =~ "errxit" ]]
+
+    cd "$E2E_TEST_DIR/dest" || return 1
+    local branch_name
+    branch_name=$(git branch -a | grep "update-from-main" | head -1 | tr -d ' *')
+    [[ -n "$branch_name" ]] || { echo "No update-from-main branch found"; return 1; }
+
+    # Inspect the replayed source commit itself, not gitmux's wrapper tip: its
+    # committer date must equal its preserved 2019 author date.
+    local target ad cdate
+    target=$(git log --format="%H %s" "$branch_name" | grep "Old authored work" | head -1 | cut -d' ' -f1)
+    [[ -n "$target" ]] || { echo "Replayed commit not found"; return 1; }
+    ad=$(git log -1 --format="%aI" "$target")
+    cdate=$(git log -1 --format="%cI" "$target")
+    echo "author=$ad committer=$cdate" >&2
+    [[ "$ad" == 2019-* ]]
+    [[ "$ad" == "$cdate" ]]
+
+    teardown_local_repos
+}
+
+@test "e2e: PRESERVE_COMMITTER_DATES=false keeps git's default (committer date != author date)" {
+    setup_local_repos
+
+    cd "$E2E_TEST_DIR/source" || return 1
+    echo "content" > file.txt
+    git add .
+    GIT_AUTHOR_DATE="2019-06-15T12:00:00-05:00" \
+    GIT_COMMITTER_DATE="2026-01-02T03:04:05-05:00" \
+        git commit -m "Old authored work"
+    git push origin main
+
+    # Opt out: committer date should become the rebase time, not 2019.
+    cd "$BATS_TEST_DIRNAME/.." || return 1
+    run bash -c "PRESERVE_COMMITTER_DATES=false ./gitmux.sh \
+        -r '$E2E_TEST_DIR/source' \
+        -t '$E2E_TEST_DIR/dest' \
+        -b main \
+        -k <<< 'y' 2>&1"
+    echo "gitmux output: $output" >&2
+    [[ ! "$output" =~ "errxit" ]]
+
+    cd "$E2E_TEST_DIR/dest" || return 1
+    local branch_name
+    branch_name=$(git branch -a | grep "update-from-main" | head -1 | tr -d ' *')
+    [[ -n "$branch_name" ]] || { echo "No update-from-main branch found"; return 1; }
+
+    # Same replayed commit; with preservation disabled its committer date is the
+    # rebase time, so it differs from the 2019 author date.
+    local target ad cdate
+    target=$(git log --format="%H %s" "$branch_name" | grep "Old authored work" | head -1 | cut -d' ' -f1)
+    [[ -n "$target" ]] || { echo "Replayed commit not found"; return 1; }
+    ad=$(git log -1 --format="%aI" "$target")
+    cdate=$(git log -1 --format="%cI" "$target")
+    echo "author=$ad committer=$cdate" >&2
+    [[ "$ad" == 2019-* ]]
+    [[ "$cdate" != 2019-* ]]
+
+    teardown_local_repos
 }

--- a/tests/test_gitmux_unit.bats
+++ b/tests/test_gitmux_unit.bats
@@ -648,6 +648,13 @@ setup_multipath_helpers() {
     cat > "${MULTIPATH_HELPER}" << 'HELPER_HEADER'
 #!/usr/bin/env bash
 errcho() { printf "%s\n" "$@" 1>&2; }
+# Stub gitmux's logging helpers so extracted functions that call them (e.g.
+# validate_no_dest_overlap's rename-lineage warning) run cleanly in isolation.
+log() { :; }
+log_info() { :; }
+log_warn() { :; }
+log_error() { :; }
+log_debug() { :; }
 HELPER_HEADER
 
     # Extract functions
@@ -1790,4 +1797,32 @@ Generated with [Some Tool](https://example.com)"
     [[ -f "lib/file.txt" ]]
 
     teardown_local_repos
+}
+
+# =============================================================================
+# Rename lineage: two mappings with DISTINCT sources but the SAME destination.
+# This is how a file's full history is reassembled when it was renamed over
+# time (e.g. old/name.py and new/name.py both -> dot.py). It must be allowed
+# (with a warning); a genuine duplicate (same source twice) must still error.
+# =============================================================================
+
+@test "validate_no_dest_overlap: allows duplicate dest from distinct sources (rename lineage)" {
+    setup_multipath_helpers
+    local us=$'\x1f'
+    run validate_no_dest_overlap "old/name.py${us}dot.py" "new/name.py${us}dot.py"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "validate_no_dest_overlap: still rejects duplicate dest from identical source" {
+    setup_multipath_helpers
+    local us=$'\x1f'
+    run validate_no_dest_overlap "same/src.py${us}dot.py" "same/src.py${us}dot.py"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "validate_no_dest_overlap: rejects parent/child overlap even from distinct sources" {
+    setup_multipath_helpers
+    local us=$'\x1f'
+    run validate_no_dest_overlap "a/x${us}lib" "b/y${us}lib/utils"
+    [[ "$status" -ne 0 ]]
 }

--- a/tests/test_gitmux_unit.bats
+++ b/tests/test_gitmux_unit.bats
@@ -1942,3 +1942,33 @@ Generated with [Some Tool](https://example.com)"
 
     teardown_local_repos
 }
+
+# =============================================================================
+# The auto-generated PR body must name the real destination branch (-b), not the
+# 'trunk' default. Regression guard for the DESTINATION_BRANCH/destination_branch
+# casing bug where the body showed 'trunk' while the PR actually targeted -b.
+# =============================================================================
+
+@test "e2e: PR body names the actual destination branch, not the default" {
+    setup_local_repos
+
+    cd "$E2E_TEST_DIR/source" || return 1
+    echo "content" > file.txt
+    git add .
+    git commit -m "work"
+    git push origin main
+
+    cd "$BATS_TEST_DIRNAME/.." || return 1
+    run bash -c "./gitmux.sh \
+        -r '$E2E_TEST_DIR/source' \
+        -t '$E2E_TEST_DIR/dest' \
+        -b main \
+        -k <<< 'y' 2>&1"
+    echo "gitmux output: $output" >&2
+    [[ ! "$output" =~ "errxit" ]]
+
+    # -b main was passed; the body must say 'main', not the 'trunk' default.
+    grep -qF "Destination branch (base): \`main\`" <<< "$output"
+
+    teardown_local_repos
+}


### PR DESCRIPTION
## Summary

Three correctness fixes to the extraction pipeline, each surfaced while
extracting a single file that had been **renamed several times** across a
repo's history into its own repo. All three are independent and land as
separate commits, each with tests.

## The fixes

1. **Allow rename lineage in destination-overlap validation** (`fb3520a`)
   Reassembling a file's full history means mapping two (or more) distinct
   sources onto the **same destination** (e.g. `old/name.py` and
   `new/name.py` → `dot.py`). `validate_no_dest_overlap` rejected that as a
   duplicate-destination conflict. It now receives `source<US>dest` pairs and
   distinguishes a genuine duplicate (same source twice — still an error) from
   rename lineage (distinct sources — allowed with a warning).

2. **Preserve original commit dates when rebasing** (`45c5690`)
   `git rebase` stamps every replayed commit with the current time, so an
   extraction collapsed the source timeline into the moment gitmux ran — and
   GitHub, which orders/groups commits by committer date, rendered the entire
   imported history as a single day. The rebase now passes
   `--committer-date-is-author-date` so each commit keeps its original date.
   On by default; opt out with `PRESERVE_COMMITTER_DATES=false`.

3. **Show the actual destination branch in the PR body** (`6e42ee7`)
   The PR description printed `${DESTINATION_BRANCH}` — the uppercase default
   (`trunk`) that `-b` never updates — while the PR was opened against
   `${destination_branch}` (the `-b` value). A PR correctly targeting `main`
   described its base as `trunk`. Fixed to use the same lowercase variable
   `--base` uses.

## Tests

- Unit: rename lineage (allowed), identical-source duplicate (rejected),
  parent/child overlap from distinct sources (rejected); the
  `committer_date_rebase_flag` contract (default-on / explicit-true / opt-out).
- End-to-end (full `gitmux.sh` against local repos): paired opt-in/opt-out
  runs prove the committer date is preserved **only** when enabled (isolating
  the flag as the cause), and a run asserting the PR body names the `-b` branch.
- Full `bats` suite + `shellcheck` (`gitmux.sh` and the `.bats` file) pass.

## Note

The env-var reference on the usage docs site (`gitmux.com/usage.html`) should
gain an entry for `PRESERVE_COMMITTER_DATES` (default `true`).
