### PR TITLE
ci: source integration test-repo owner from a variable

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,7 +50,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GH_HOST: github.com
-          GITHUB_OWNER: ${{ github.repository_owner }}
+          # Owner of the throwaway test repos. Point the repo/org variable
+          # INTEGRATION_TEST_OWNER at a dedicated CI org so GH_TOKEN can be a
+          # token scoped to ONLY that org -- a leak or a buggy cleanup then can't
+          # reach real repos. Falls back to the repository owner when unset.
+          GITHUB_OWNER: ${{ vars.INTEGRATION_TEST_OWNER || github.repository_owner }}
         run: |
           echo "Running integration tests..."
           echo "Test repos will be created under: ${GITHUB_OWNER}"
@@ -60,9 +64,10 @@ jobs:
         if: failure() && steps.check-token.outputs.has_token == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_OWNER: ${{ vars.INTEGRATION_TEST_OWNER || github.repository_owner }}
         run: |
-          echo "Cleaning up any leftover test repositories..."
-          repos=$(gh repo list --limit 100 --json nameWithOwner,name --jq '.[]|select(.name|startswith("gitmux_test_")).nameWithOwner' 2>/dev/null || echo "")
+          echo "Cleaning up any leftover test repositories under ${GITHUB_OWNER}..."
+          repos=$(gh repo list "${GITHUB_OWNER}" --limit 100 --json nameWithOwner,name --jq '.[]|select(.name|startswith("gitmux_test_")).nameWithOwner' 2>/dev/null || echo "")
           if [[ -n "$repos" ]]; then
             for r in $repos; do
               echo "Deleting leftover test repo: $r"


### PR DESCRIPTION
Lets `GITHUB_OWNER` for the integration tests come from a repo/org variable `INTEGRATION_TEST_OWNER` (falling back to the repo owner when unset).

Purpose: point it at a **dedicated, throwaway CI org** so the `GH_TOKEN` secret can be a token scoped to *only* that org. Today the tests run against the personal account with a classic `repo`+`delete_repo` PAT that can delete/rewrite **any** repo; scoping owner + token to a sacrificial org means a token leak or a buggy cleanup can't touch real repos.

Also scopes the failure-cleanup `gh repo list` to `${GITHUB_OWNER}` explicitly (required for an org-scoped token, and safer).

No behavior change until `INTEGRATION_TEST_OWNER` is set and the org-scoped token is installed.