### PR TITLE
fix: default destination branch to main instead of trunk

### DIFF
--- a/gitmux.sh
+++ b/gitmux.sh
@@ -2319,7 +2319,7 @@ if ! _repo_existence="$(git fetch destination 2>&1)"; then
       errxit "Failed to configure git authentication via gh CLI"
     fi
     git remote --verbose show
-    # Rename default branch to trunk (gitmux convention) if needed
+    # Rename the new repo's default branch to the destination branch if needed
     _current_branch=$(git branch --show-current)
     if [[ "${_current_branch}" != "${destination_branch}" ]]; then
       log "Renaming branch ${_current_branch} to ${destination_branch}"
@@ -2343,12 +2343,12 @@ if ! _repo_existence="$(git fetch destination 2>&1)"; then
     # Our brand new repo destination branch needs at least one commit (to be the base branch of a PR).
     # This will also help remind us where this repository came from.
     git status
-    # A local 'trunk' branch probably already exists
-    if ! git checkout -b "gitmux-dest-${destination_branch}" destination/trunk; then
+    # The destination branch now exists on the 'destination' remote
+    if ! git checkout -b "gitmux-dest-${destination_branch}" "destination/${destination_branch}"; then
       errxit "Failed to checkout destination branch from new repository"
     fi
-    if ! git pull destination trunk; then
-      errxit "Failed to pull from destination trunk"
+    if ! git pull destination "${destination_branch}"; then
+      errxit "Failed to pull '${destination_branch}' from destination"
     fi
     # Unstage everything (from ${DESTINATION_PR_BRANCH_NAME})
     if ! _rm_output=$(git rm -r --cached . 2>&1); then
@@ -2360,7 +2360,7 @@ if ! _repo_existence="$(git fetch destination 2>&1)"; then
     if ! git commit --message 'Hello: this repository was created by gitmux.' --allow-empty; then
       log_warn "Failed to create initial commit - continuing anyway"
     fi
-    if ! git push destination "gitmux-dest-${destination_branch}:trunk"; then
+    if ! git push destination "gitmux-dest-${destination_branch}:${destination_branch}"; then
       errxit "Failed to push initial commit to destination repository"
     fi
     # Now go back to the build branch.

--- a/gitmux.sh
+++ b/gitmux.sh
@@ -251,6 +251,28 @@ _cmd_exists () {
   fi
 }
 
+# Retry a command up to <max> times with a fixed <delay> (seconds) between
+# attempts, returning 0 as soon as it succeeds and non-zero if every attempt
+# fails. Used to tolerate a freshly created repository briefly 404ing for the
+# credential that created it: fine-grained PATs grant per-repo access
+# asynchronously, so a brand-new repo may not be reachable for a few seconds.
+# Usage: _retry <max-attempts> <delay-seconds> <command> [args...]
+_retry () {
+  local _max="$1" _delay="$2"
+  shift 2
+  local _attempt
+  for ((_attempt = 1; _attempt <= _max; _attempt++)); do
+    if "$@"; then
+      return 0
+    fi
+    if ((_attempt < _max)); then
+      log_warn "Command failed (attempt ${_attempt}/${_max}): $*; retrying in ${_delay}s..."
+      sleep "${_delay}"
+    fi
+  done
+  return 1
+}
+
 # Check if git-filter-repo is available.
 # Returns:
 #   0 if git-filter-repo is in PATH and executable
@@ -2338,19 +2360,9 @@ if ! _repo_existence="$(git fetch destination 2>&1)"; then
 
     log "Attempting (again) to fetch remote 'destination' --> ${destination_repository}"
     # A just-created repository can briefly 404 for the credential that created
-    # it -- notably fine-grained PATs, whose per-repo access propagates
-    # asynchronously -- so retry the first fetch with backoff instead of failing
-    # the whole run on that race.
-    _fetch_ok=false
-    for ((_fa = 1; _fa <= 10; _fa++)); do
-      if git fetch destination; then
-        _fetch_ok=true
-        break
-      fi
-      log_warn "Destination not reachable yet (attempt ${_fa}/10); waiting for GitHub to propagate the new repository..."
-      sleep 3
-    done
-    if [ "${_fetch_ok}" != true ]; then
+    # it (fine-grained PATs grant per-repo access asynchronously), so retry the
+    # first fetch instead of failing the whole run on that race.
+    if ! _retry 10 3 git fetch destination; then
       errxit "Failed to fetch from newly created destination repository"
     fi
     # Our brand new repo destination branch needs at least one commit (to be the base branch of a PR).

--- a/gitmux.sh
+++ b/gitmux.sh
@@ -2337,7 +2337,20 @@ if ! _repo_existence="$(git fetch destination 2>&1)"; then
     ########## </GH CREATE REPO> ################
 
     log "Attempting (again) to fetch remote 'destination' --> ${destination_repository}"
-    if ! git fetch destination; then
+    # A just-created repository can briefly 404 for the credential that created
+    # it -- notably fine-grained PATs, whose per-repo access propagates
+    # asynchronously -- so retry the first fetch with backoff instead of failing
+    # the whole run on that race.
+    _fetch_ok=false
+    for ((_fa = 1; _fa <= 10; _fa++)); do
+      if git fetch destination; then
+        _fetch_ok=true
+        break
+      fi
+      log_warn "Destination not reachable yet (attempt ${_fa}/10); waiting for GitHub to propagate the new repository..."
+      sleep 3
+    done
+    if [ "${_fetch_ok}" != true ]; then
       errxit "Failed to fetch from newly created destination repository"
     fi
     # Our brand new repo destination branch needs at least one commit (to be the base branch of a PR).

--- a/gitmux.sh
+++ b/gitmux.sh
@@ -1396,7 +1396,7 @@ _WORKSPACE=$(pwd)
 
 # The following is unnecessary when doing a full clone.
 # Without a full clone, this procedure just doesnt work quite right.
-#git fetch --update-shallow --shallow-since=1month --update-head-ok --progress origin trunk
+#git fetch --update-shallow --shallow-since=1month --update-head-ok --progress origin main
 
 # If a non-default ref is specified, fetch it explicitly and perform a checkout.
 if [[ -n "${source_git_ref}" ]]; then

--- a/gitmux.sh
+++ b/gitmux.sh
@@ -409,7 +409,7 @@ SUBDIRECTORY_FILTER="${SUBDIRECTORY_FILTER:-}"
 SOURCE_GIT_REF="${SOURCE_GIT_REF:-}"
 DESTINATION_PATH="${DESTINATION_PATH:-}"
 DESTINATION_REPOSITORY="${DESTINATION_REPOSITORY:-}"
-DESTINATION_BRANCH="${DESTINATION_BRANCH:-trunk}"
+DESTINATION_BRANCH="${DESTINATION_BRANCH:-main}"
 SUBMIT_PR="${SUBMIT_PR:-false}"
 REV_LIST_FILES="${REV_LIST_FILES:-}"
 INTERACTIVE_REBASE="${INTERACTIVE_REBASE:-false}"
@@ -615,7 +615,7 @@ function show_help()
   _help_flag "-l <rev-list>" "Extract specific files (git rev-list format)"
 
   _help_header "Destination"
-  _help_flag "-b <branch>" "Target branch in destination (default: trunk)"
+  _help_flag "-b <branch>" "Target branch in destination (default: main)"
   _help_flag "-c" "Create destination repo if missing (requires gh)"
 
   _help_header "Rebase"

--- a/test_gitmux.sh
+++ b/test_gitmux.sh
@@ -175,7 +175,7 @@ createRepository "${GITHUB_OWNER}" "${DESTINATION_REPOSITORY_NAME}"
 repositoriesToDelete+=("${GITHUB_OWNER}/${DESTINATION_REPOSITORY_NAME}")
 git remote add destination_remote_name "https://${GITHUB_OWNER}:${GH_TOKEN}@${GH_HOST}/${GITHUB_OWNER}/${DESTINATION_REPOSITORY_NAME}.git"
 git fetch --update-head-ok destination_remote_name
-# This actually creates a local 'main' tracking branch.
+# Switch to the local 'main' branch that 'git init --initial-branch=main' created above.
 git checkout main
 # Now back to current branch.
 git checkout -b destination_current_branch --track destination_remote_name/main

--- a/test_gitmux.sh
+++ b/test_gitmux.sh
@@ -121,12 +121,12 @@ createRepository() {
   git commit --message 'Hello: this repository was created by gitmux.' --allow-empty
   # Mask token in verbose output
   git remote --verbose show | sed "s/${GH_TOKEN}/[REDACTED]/g"
-  # Rename branch to trunk (gitmux convention) and push
-  git branch -m trunk
+  # Rename branch to main (gitmux convention) and push
+  git branch -m main
   log "pushing change to hello"
-  git push hello "trunk:trunk"
-  # Set trunk as default branch on GitHub
-  gh repo edit "${_owner}/${_project}" --default-branch trunk
+  git push hello "main:main"
+  # Set main as default branch on GitHub
+  gh repo edit "${_owner}/${_project}" --default-branch main
   pwd
   _popd && _popd
   pwd
@@ -142,13 +142,13 @@ createRepository() {
 SOURCE_REPOSITORY_NAME="gitmux_test_source_$(rands)"
 mkdir -p "${SOURCE_REPOSITORY_NAME}"
 _pushd "${SOURCE_REPOSITORY_NAME}" && SOURCE_REPOSITORY_PATH="$(pwd)"
-git init --initial-branch=trunk
+git init --initial-branch=main
 createRepository "${GITHUB_OWNER}" "${SOURCE_REPOSITORY_NAME}"
 repositoriesToDelete+=("${GITHUB_OWNER}/${SOURCE_REPOSITORY_NAME}")
 git remote add source_remote_name "https://${GITHUB_OWNER}:${GH_TOKEN}@${GH_HOST}/${GITHUB_OWNER}/${SOURCE_REPOSITORY_NAME}.git"
 log "Fetching in $(pwd)"
 git fetch source_remote_name
-git checkout -b something-new --track source_remote_name/trunk
+git checkout -b something-new --track source_remote_name/main
 echo "Hello World" > "hello.txt"
 echo "## wat" > 'wat.md'
 mkdir -p toto
@@ -170,15 +170,15 @@ DESTINATION_REPOSITORY_NAME="gitmux_test_destination_$(rands)"
 mkdir -p "${DESTINATION_REPOSITORY_NAME}"
 _pushd "${DESTINATION_REPOSITORY_NAME}"
 DESTINATION_REPOSITORY_PATH="$(pwd)"
-git init --initial-branch=trunk
+git init --initial-branch=main
 createRepository "${GITHUB_OWNER}" "${DESTINATION_REPOSITORY_NAME}"
 repositoriesToDelete+=("${GITHUB_OWNER}/${DESTINATION_REPOSITORY_NAME}")
 git remote add destination_remote_name "https://${GITHUB_OWNER}:${GH_TOKEN}@${GH_HOST}/${GITHUB_OWNER}/${DESTINATION_REPOSITORY_NAME}.git"
 git fetch --update-head-ok destination_remote_name
-# This actually creates a local 'trunk' tracking branch.
-git checkout trunk
+# This actually creates a local 'main' tracking branch.
+git checkout main
 # Now back to current branch.
-git checkout -b destination_current_branch --track destination_remote_name/trunk
+git checkout -b destination_current_branch --track destination_remote_name/main
 git commit --allow-empty -m 'initial destination repo commit: gitmux test'
 _popd && _popd
 
@@ -221,7 +221,7 @@ echo
 ##########################################
 
 test_rebase_strategy_theirs_with_existing_upstream_destination() {
-  ./gitmux.sh -v -r "${SOURCE_REPOSITORY_PATH}" -t "${DESTINATION_REPOSITORY_PATH}" -p place_content_in_this_subdir -b trunk -X theirs
+  ./gitmux.sh -v -r "${SOURCE_REPOSITORY_PATH}" -t "${DESTINATION_REPOSITORY_PATH}" -p place_content_in_this_subdir -b main -X theirs
   _pushd "${DESTINATION_REPOSITORY_PATH}"
   git checkout "update-from-something-new-${_sha}-rebase-strategy-theirs"
   local output=''
@@ -387,12 +387,12 @@ test_multipath_migration() {
   mkdir -p "${MULTIPATH_SOURCE_NAME}"
   _pushd "${MULTIPATH_SOURCE_NAME}"
   MULTIPATH_SOURCE_PATH="$(pwd)"
-  git init --initial-branch=trunk
+  git init --initial-branch=main
   createRepository "${GITHUB_OWNER}" "${MULTIPATH_SOURCE_NAME}"
   repositoriesToDelete+=("${GITHUB_OWNER}/${MULTIPATH_SOURCE_NAME}")
   git remote add multipath_source_remote "https://${GITHUB_OWNER}:${GH_TOKEN}@${GH_HOST}/${GITHUB_OWNER}/${MULTIPATH_SOURCE_NAME}.git"
   git fetch multipath_source_remote
-  git checkout -b multipath-test --track multipath_source_remote/trunk
+  git checkout -b multipath-test --track multipath_source_remote/main
 
   # Create src/ directory with some files
   mkdir -p src
@@ -417,13 +417,13 @@ test_multipath_migration() {
   mkdir -p "${MULTIPATH_DEST_NAME}"
   _pushd "${MULTIPATH_DEST_NAME}"
   MULTIPATH_DEST_PATH="$(pwd)"
-  git init --initial-branch=trunk
+  git init --initial-branch=main
   createRepository "${GITHUB_OWNER}" "${MULTIPATH_DEST_NAME}"
   repositoriesToDelete+=("${GITHUB_OWNER}/${MULTIPATH_DEST_NAME}")
   git remote add multipath_dest_remote "https://${GITHUB_OWNER}:${GH_TOKEN}@${GH_HOST}/${GITHUB_OWNER}/${MULTIPATH_DEST_NAME}.git"
   git fetch --update-head-ok multipath_dest_remote
-  git checkout trunk
-  git checkout -b multipath_dest_branch --track multipath_dest_remote/trunk
+  git checkout main
+  git checkout -b multipath_dest_branch --track multipath_dest_remote/main
   git commit --allow-empty -m 'initial destination repo commit: multipath test'
   _popd
 

--- a/test_gitmux.sh
+++ b/test_gitmux.sh
@@ -466,6 +466,40 @@ test_multipath_migration() {
   _popd
 }
 
+##########################################
+#### Test 7:
+####    - -c (create repo) with an explicit NON-default branch (-b release)
+####    - guards that the create/bootstrap path honors -b instead of
+####      hardcoding the base branch
+##########################################
+
+test_create_destination_with_nondefault_branch() {
+  NEW_REPO_PROJECT_NAME="gitmux_test_destination_$(rands)"
+  repositoriesToDelete+=("${GITHUB_OWNER}/${NEW_REPO_PROJECT_NAME}")
+  NEW_REPO_NO_UPSTREAM_YET="https://${GITHUB_OWNER}:${GH_TOKEN}@${GH_HOST}/${GITHUB_OWNER}/${NEW_REPO_PROJECT_NAME}.git"
+  # -b names a branch other than the 'main' default; the create/bootstrap path
+  # must target it (it previously hardcoded the base branch).
+  ./gitmux.sh -v -c -r "${SOURCE_REPOSITORY_PATH}" -t "${NEW_REPO_NO_UPSTREAM_YET}" -b release
+  log "Cloning the created repo; its default branch should be the -b value 'release'."
+  git clone "${NEW_REPO_NO_UPSTREAM_YET}"
+  _pushd "${NEW_REPO_PROJECT_NAME}"
+  local _default_branch=''
+  _default_branch=$(git branch --show-current)
+  if [ "${_default_branch}" != "release" ]; then
+    errcho "Expected created repo default branch 'release', got '${_default_branch}'"
+    errcleanup
+  fi
+  echo "✅ Success: -c honored -b release (default branch is 'release')"
+  git checkout "update-from-something-new-${_sha}-rebase-strategy-theirs"
+  local output=''
+  if output=$(cat hello.txt) && [ "${output}" == "Hello World" ]; then
+    echo "${output}" && echo "✅ Success"
+  else
+    errcleanup
+  fi
+  _popd
+}
+
 run_test_cases() {
   test_defaults_with_existing_upstream_destination
   test_rebase_strategy_theirs_with_existing_upstream_destination
@@ -473,6 +507,7 @@ run_test_cases() {
   #test_defaults_add_orgteam
   test_defaults_destination_dne_yet_only_wat
   test_defaults_destination_dne_yet_only_toto
+  test_create_destination_with_nondefault_branch
   test_multipath_migration
 }
 

--- a/tests/test_gitmux_unit.bats
+++ b/tests/test_gitmux_unit.bats
@@ -1945,12 +1945,21 @@ Generated with [Some Tool](https://example.com)"
 
 # =============================================================================
 # The auto-generated PR body must name the real destination branch (-b), not the
-# 'trunk' default. Regression guard for the DESTINATION_BRANCH/destination_branch
-# casing bug where the body showed 'trunk' while the PR actually targeted -b.
+# frozen DESTINATION_BRANCH default. Regression guard for the
+# DESTINATION_BRANCH/destination_branch casing bug where the body echoed the
+# uppercase default while the PR actually targeted -b. Targets a NON-default
+# branch (the default is 'main') so the -b value and the default differ and the
+# guard actually bites.
 # =============================================================================
 
 @test "e2e: PR body names the actual destination branch, not the default" {
     setup_local_repos
+
+    # Give the destination a branch other than the 'main' default, and target it.
+    cd "$E2E_TEST_DIR/dest" || return 1
+    git checkout -q -b release
+    git push -q origin release
+    git checkout -q main
 
     cd "$E2E_TEST_DIR/source" || return 1
     echo "content" > file.txt
@@ -1962,13 +1971,13 @@ Generated with [Some Tool](https://example.com)"
     run bash -c "./gitmux.sh \
         -r '$E2E_TEST_DIR/source' \
         -t '$E2E_TEST_DIR/dest' \
-        -b main \
+        -b release \
         -k <<< 'y' 2>&1"
     echo "gitmux output: $output" >&2
     [[ ! "$output" =~ "errxit" ]]
 
-    # -b main was passed; the body must say 'main', not the 'trunk' default.
-    grep -qF "Destination branch (base): \`main\`" <<< "$output"
+    # -b release differs from the 'main' default; the body must reflect -b.
+    grep -qF "Destination branch (base): \`release\`" <<< "$output"
 
     teardown_local_repos
 }

--- a/tests/test_gitmux_unit.bats
+++ b/tests/test_gitmux_unit.bats
@@ -655,6 +655,8 @@ log_info() { :; }
 log_warn() { :; }
 log_error() { :; }
 log_debug() { :; }
+# Stub sleep so _retry's inter-attempt delay doesn't slow the tests down.
+sleep() { :; }
 HELPER_HEADER
 
     # Extract functions
@@ -664,6 +666,7 @@ HELPER_HEADER
         sed -n '/^function parse_path_mapping () {/,/^}/p' "${GITMUX_SCRIPT}"
         sed -n '/^function validate_no_dest_overlap () {/,/^}/p' "${GITMUX_SCRIPT}"
         sed -n '/^function committer_date_rebase_flag () {/,/^}/p' "${GITMUX_SCRIPT}"
+        sed -n '/^_retry () {/,/^}/p' "${GITMUX_SCRIPT}"
     } >> "${MULTIPATH_HELPER}"
 
     source "${MULTIPATH_HELPER}"
@@ -1980,4 +1983,35 @@ Generated with [Some Tool](https://example.com)"
     grep -qF "Destination branch (base): \`release\`" <<< "$output"
 
     teardown_local_repos
+}
+
+# =============================================================================
+# _retry: run a command until it succeeds, up to <max> attempts. Guards the
+# post-create fetch against a freshly created repo briefly 404ing for the
+# credential that made it.
+# =============================================================================
+
+@test "_retry: succeeds immediately when the command passes on the first try" {
+    setup_multipath_helpers
+    run _retry 3 0 true
+    [[ "$status" -eq 0 ]]
+}
+
+@test "_retry: keeps trying and succeeds once the command starts passing" {
+    setup_multipath_helpers
+    local counter="${BATS_TEST_TMPDIR}/retry_count"
+    printf '0' > "$counter"
+    # Fails on attempts 1 and 2, then succeeds on attempt 3.
+    _flaky() {
+        local n; n=$(< "$counter"); n=$((n + 1)); printf '%s' "$n" > "$counter"
+        [ "$n" -ge 3 ]
+    }
+    _retry 5 0 _flaky
+    [[ "$(< "$counter")" -eq 3 ]]
+}
+
+@test "_retry: returns non-zero after exhausting all attempts" {
+    setup_multipath_helpers
+    run _retry 3 0 false
+    [[ "$status" -ne 0 ]]
 }


### PR DESCRIPTION
Makes `main` the default destination branch, fixes the `-c` create path to honor `-b`, and hardens that path against a fresh-repo propagation race.

## ⚠️ Behavior change
The default destination branch changes from **`trunk`** to **`main`** (GitHub's default). Anyone relying on the `trunk` default must now pass `-b trunk` (or set `DESTINATION_BRANCH=trunk`) explicitly. Rationale: GitHub creates repos with `main`, so the `trunk` default made gitmux fail at preflight/rebase looking for a nonexistent `trunk` when run against a normal repo without `-b`.

## What changed
- **Honor `-b` in the `-c` create/bootstrap path** (`8681f12`) — it hardcoded `trunk` when checking out / pulling / pushing the destination base branch, so `-c -b <anything-but-trunk>` was broken. Now uses `${destination_branch}` throughout.
- **Default the destination branch to `main`** (`03240e6`) — flips the default + `--help`, migrates the integration test onto `main`, and retargets the PR-body regression test at a non-default branch so it still guards the `DESTINATION_BRANCH` casing bug now that the default would otherwise equal the tested value.
- **Retry the post-create fetch** (`fb74eb2`) — a freshly created repo can 404 for a fine-grained PAT whose per-repo access propagates asynchronously; the old `trunk` default masked this via incidental delay from the now-skipped rename/push steps.
- **Review-round polish** (`09d46a0`, `a958fcd`, `6f285ce`) — extract the retry into a reusable, unit-tested `_retry` helper; add a `-c -b <non-default>` integration test; fix stale comments.

Backward compatibility for the branch name is preserved via `-b` / `DESTINATION_BRANCH`.

## Review
Two independent code reviews (pr-review-toolkit + superpowers) ran in parallel — **no Critical/Important/Medium correctness defects.** Both empirically verified the change (proved the retargeted regression guard fails on the reintroduced casing bug, confirmed shellcheck-clean, confirmed `git branch -m main` on `main` is a clean no-op). All findings at every severity were addressed in this PR.

## Test plan
- [x] **Full bats suite (176) + shellcheck** green (`gitmux.sh`, `test_gitmux.sh`, `.bats`) — locally and in CI.
- [x] **Integration Tests (CI)** — create/extract/delete real repos on `main` in the `gitmux-ci` org; the fresh-repo propagation race actually fired and `_retry` absorbed it (`"Destination not reachable yet (attempt 1/10)…"`).
- [x] **`-c -b release` integration case** — asserts a repo created with a non-default branch has default branch `release` (locks in the bootstrap `-b` fix).
- [x] **`_retry` unit tests** — first-try success, eventual success (fails twice then passes), and exhaustion.
- [x] **`gitmux -h`** shows `Target branch in destination (default: main)`; `gitmux -V` → `gitmux 2.0.0`.
- Post-merge: none required — a CLI behavior change fully exercised by CI. The website `-b` default (currently stale on gitmux.com) is updated in the follow-up docs PR.
