### PR TITLE
docs: fix audit findings across README and the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Every commit, every blame, every bisect — preserved.
 ## Why gitmux?
 
 - **Full history** — Not a copy-paste. Every commit follows the code.
-- **PR-based** — Changes go through pull requests, never direct pushes.
+- **PR-based** — Changes to existing repos go through pull requests.
 - **10x faster** — Auto-uses [git-filter-repo](https://github.com/newren/git-filter-repo) when available.
 - **Multi-path** — Migrate multiple directories in one operation.
 
@@ -31,6 +31,8 @@ Every commit, every blame, every bisect — preserved.
 git clone https://github.com/stavxyz/gitmux.git
 cd gitmux && ./gitmux.sh -h
 ```
+
+**Requires:** `git` and `jq`. `gh` (GitHub CLI) is needed for `-s`, `-c`, and `-z`.
 
 **Optional** (10x speedup): `brew install git-filter-repo` or `pip install git-filter-repo`
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,7 +10,7 @@ nav_order: 5
 
 ### Why doesn't gitmux push directly to my destination branch?
 
-That's dangerous. Pull requests provide an audit trail and allow review before merging. gitmux creates a unique feature branch for each sync (`update-from-<branch>-<sha>`).
+That's dangerous. Pull requests provide an audit trail and allow review before merging. gitmux creates a unique feature branch for each sync (e.g. `update-from-<branch>-<sha>-rebase-strategy-theirs`).
 
 ### Can I use a local directory as the source?
 
@@ -62,6 +62,21 @@ Use `\:` to escape literal colons:
 -m 'path\:with\:colons:destination'
 ```
 
+### Can I reassemble a file's history across renames?
+
+Yes. If a file was renamed over time, map each of its historical paths to the
+same destination with repeated `-m`. gitmux allows two mappings to share a
+destination as long as their sources differ (it warns that it's treating them as
+rename lineage):
+
+```bash
+./gitmux.sh \
+  -r source -t dest \
+  -m 'old/name.py:dot.py' \
+  -m 'new/name.py:dot.py' \
+  -s
+```
+
 ## Author Rewriting
 
 ### How do I remove AI-generated attribution from commits?
@@ -108,6 +123,13 @@ Use `--dry-run` (or `-D`). This shows you the source/destination, which commits 
 ### How do I see more detailed output?
 
 Use `-v` for verbose output (debug level), or set `--log-level debug` for maximum detail. Log levels from most to least verbose: `debug`, `info` (default), `warning`, `error`.
+
+### Why are all my commit dates the day I ran gitmux?
+
+By default gitmux preserves each commit's original authorship date as its
+committer date, so the extracted history keeps its real timeline. If your commits
+all show today's date, committer-date preservation was turned off — set
+`PRESERVE_COMMITTER_DATES=true` (the default) to keep the original dates.
 
 ### Why did gitmux fail before doing any work?
 

--- a/docs/filter-backend.md
+++ b/docs/filter-backend.md
@@ -119,4 +119,9 @@ gitmux provides the same features regardless of backend:
 - Co-author removal (`--coauthor-action`)
 - Specific file extraction (`-l`)
 
-The backend choice only affects performance, not functionality.
+The backend choice is almost entirely about performance. The one functional
+difference: setting a **committer** identity different from the **author**
+(`--committer-name`/`--committer-email` diverging from `--author-*`) is only
+supported by the `filter-branch` backend. Under `filter-repo`, gitmux applies
+the same name/email to both author and committer and warns — use
+`--filter-backend filter-branch` if you need them to differ.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Every commit, every blame, every bisect — preserved.
 ## Why gitmux?
 
 - **Full history** — Not a copy-paste. Every commit follows the code.
-- **PR-based** — Changes go through pull requests, never direct pushes.
+- **PR-based** — Changes to existing repos go through pull requests.
 - **10x faster** — Auto-uses [git-filter-repo](https://github.com/newren/git-filter-repo) when available.
 - **Multi-path** — Migrate multiple directories in one operation.
 
@@ -33,6 +33,8 @@ Every commit, every blame, every bisect — preserved.
 git clone https://github.com/stavxyz/gitmux.git
 cd gitmux && ./gitmux.sh -h
 ```
+
+**Requires:** `git` and `jq`. `gh` (GitHub CLI) is needed for `-s`, `-c`, and `-z`.
 
 **Optional** (10x speedup): `brew install git-filter-repo` or `pip install git-filter-repo`
 

--- a/docs/rebase-strategies.md
+++ b/docs/rebase-strategies.md
@@ -98,8 +98,9 @@ PRESERVE_COMMITTER_DATES=false ./gitmux.sh -r source -t dest
 ## Custom Options with `-o`
 
 `-o` **replaces** gitmux's entire default rebase-options string (`--keep-empty
---autostash --merge --strategy recursive` plus the histogram diff algorithm), so
-include any of those you still want, and it is mutually exclusive with `-X`.
+--autostash --merge --strategy recursive --strategy-option theirs --strategy-option
+diff-algorithm=histogram`), so include any of those you still want, and it is
+mutually exclusive with `-X`.
 (Committer-date preservation is applied separately and is unaffected.)
 
 For advanced use cases, pass any valid `git rebase` options directly:

--- a/docs/rebase-strategies.md
+++ b/docs/rebase-strategies.md
@@ -80,7 +80,27 @@ The diff algorithm determines how git figures out what changed between two versi
 ./gitmux.sh -r source -t dest -X patience  # shorthand
 ```
 
+## Preserving Commit Dates
+
+By default (`PRESERVE_COMMITTER_DATES=true`), gitmux passes
+`--committer-date-is-author-date` to the rebase, so each replayed commit keeps
+its **original authorship date** as its committer date. Without this, `git
+rebase` stamps every commit with the current time, collapsing an extracted
+history into a single day (GitHub orders and groups commits by committer date).
+
+Set `PRESERVE_COMMITTER_DATES=false` to restore git's default (committer date =
+now):
+
+```bash
+PRESERVE_COMMITTER_DATES=false ./gitmux.sh -r source -t dest
+```
+
 ## Custom Options with `-o`
+
+`-o` **replaces** gitmux's entire default rebase-options string (`--keep-empty
+--autostash --merge --strategy recursive` plus the histogram diff algorithm), so
+include any of those you still want, and it is mutually exclusive with `-X`.
+(Committer-date preservation is applied separately and is unaffected.)
 
 For advanced use cases, pass any valid `git rebase` options directly:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -87,7 +87,6 @@ See [Rebase Strategies]({% link rebase-strategies.md %}) for detailed guidance.
 | `-n`, `--committer-name <name>` | Override committer name |
 | `-e`, `--committer-email <email>` | Override committer email |
 | `-C`, `--coauthor-action <act>` | `claude` \| `all` \| `keep` |
-| `-D`, `--dry-run` | Preview changes without modifying anything |
 
 ### Co-author Actions
 
@@ -111,6 +110,7 @@ See [Filter Backend]({% link filter-backend.md %}) for details.
 |--------|-------------|
 | `-L`, `--log-level <level>` | `debug` \| `info` \| `warning` \| `error` (default: info) |
 | `-S`, `--skip-preflight` | Skip pre-flight validation checks |
+| `-D`, `--dry-run` | Preview changes without modifying anything |
 | `-k` | Keep temp workspace for debugging |
 | `-v` | Verbose output (sets log level to debug) |
 | `-h` | Show help |
@@ -118,7 +118,7 @@ See [Filter Backend]({% link filter-backend.md %}) for details.
 
 ## Environment Variables
 
-Every CLI option can also be set via an environment variable:
+Most CLI options can also be set via an environment variable:
 
 | CLI Option | Environment Variable |
 |------------|---------------------|
@@ -139,11 +139,11 @@ Every CLI option can also be set via an environment variable:
 | `-S`, `--skip-preflight` | `SKIP_PREFLIGHT` |
 | `-L`, `--log-level` | `GITMUX_LOG_LEVEL` |
 | `-F`, `--filter-backend` | `GITMUX_FILTER_BACKEND` |
-| `--author-name` | `GITMUX_AUTHOR_NAME` |
-| `--author-email` | `GITMUX_AUTHOR_EMAIL` |
-| `--committer-name` | `GITMUX_COMMITTER_NAME` |
-| `--committer-email` | `GITMUX_COMMITTER_EMAIL` |
-| `--coauthor-action` | `GITMUX_COAUTHOR_ACTION` |
+| `-N`, `--author-name` | `GITMUX_AUTHOR_NAME` |
+| `-E`, `--author-email` | `GITMUX_AUTHOR_EMAIL` |
+| `-n`, `--committer-name` | `GITMUX_COMMITTER_NAME` |
+| `-e`, `--committer-email` | `GITMUX_COMMITTER_EMAIL` |
+| `-C`, `--coauthor-action` | `GITMUX_COAUTHOR_ACTION` |
 
 Some knobs have no CLI flag and are set only via the environment:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,11 +42,16 @@ Use `-m` multiple times to migrate several paths in one operation:
 
 Use `\:` to escape literal colons in paths. Empty string or `.` means root.
 
+Two `-m` mappings may share the same **destination** as long as their
+**sources differ** — gitmux allows it (with a warning) so you can reassemble a
+file's history across renames, e.g. mapping both `old/name.py` and `new/name.py`
+to `dot.py`.
+
 ## Destination Options
 
 | Option | Description |
 |--------|-------------|
-| `-b <branch>` | Target branch (default: main/master) |
+| `-b <branch>` | Target branch in destination (default: main) |
 | `-c` | Create destination repo if missing (requires gh) |
 
 ## Rebase Options
@@ -54,7 +59,7 @@ Use `\:` to escape literal colons in paths. Empty string or `.` means root.
 | Option | Description |
 |--------|-------------|
 | `-X <strategy>` | `theirs` \| `ours` \| `patience` (default: theirs) |
-| `-o <options>` | Custom git rebase options |
+| `-o <options>` | Custom git rebase options (mutually exclusive with `-X`) |
 | `-i` | Interactive rebase mode |
 
 By default the rebase preserves each commit's original authorship date as its
@@ -77,12 +82,12 @@ See [Rebase Strategies]({% link rebase-strategies.md %}) for detailed guidance.
 
 | Option | Description |
 |--------|-------------|
-| `--author-name <name>` | Override author name for all commits |
-| `--author-email <email>` | Override author email for all commits |
-| `--committer-name <name>` | Override committer name |
-| `--committer-email <email>` | Override committer email |
-| `--coauthor-action <act>` | `claude` \| `all` \| `keep` |
-| `--dry-run` | Preview changes without modifying anything |
+| `-N`, `--author-name <name>` | Override author name for all commits |
+| `-E`, `--author-email <email>` | Override author email for all commits |
+| `-n`, `--committer-name <name>` | Override committer name |
+| `-e`, `--committer-email <email>` | Override committer email |
+| `-C`, `--coauthor-action <act>` | `claude` \| `all` \| `keep` |
+| `-D`, `--dry-run` | Preview changes without modifying anything |
 
 ### Co-author Actions
 
@@ -96,7 +101,7 @@ See [Rebase Strategies]({% link rebase-strategies.md %}) for detailed guidance.
 
 | Option | Description |
 |--------|-------------|
-| `--filter-backend <be>` | `filter-branch` \| `filter-repo` \| `auto` |
+| `-F`, `--filter-backend <be>` | `filter-branch` \| `filter-repo` \| `auto` (default: auto) |
 
 See [Filter Backend]({% link filter-backend.md %}) for details.
 
@@ -104,24 +109,47 @@ See [Filter Backend]({% link filter-backend.md %}) for details.
 
 | Option | Description |
 |--------|-------------|
-| `--log-level <level>` | `debug` \| `info` \| `warning` \| `error` |
-| `--skip-preflight` | Skip pre-flight validation checks |
+| `-L`, `--log-level <level>` | `debug` \| `info` \| `warning` \| `error` (default: info) |
+| `-S`, `--skip-preflight` | Skip pre-flight validation checks |
 | `-k` | Keep temp workspace for debugging |
 | `-v` | Verbose output (sets log level to debug) |
 | `-h` | Show help |
+| `-V`, `--version` | Show version and exit |
 
 ## Environment Variables
 
-All options can be set via environment variables:
+Every CLI option can also be set via an environment variable:
 
 | CLI Option | Environment Variable |
 |------------|---------------------|
+| `-r` | `SOURCE_REPOSITORY` |
+| `-t` | `DESTINATION_REPOSITORY` |
+| `-d` | `SUBDIRECTORY_FILTER` |
+| `-p` | `DESTINATION_PATH` |
+| `-g` | `SOURCE_GIT_REF` |
+| `-l` | `REV_LIST_FILES` |
+| `-b` | `DESTINATION_BRANCH` |
+| `-c` | `CREATE_NEW_REPOSITORY` |
+| `-s` | `SUBMIT_PR` |
+| `-i` | `INTERACTIVE_REBASE` |
+| `-k` | `KEEP_TMP_WORKSPACE` |
+| `-X` | `MERGE_STRATEGY_OPTION_FOR_REBASE` |
+| `-o` | `REBASE_OPTIONS` |
+| `-D`, `--dry-run` | `DRY_RUN` |
+| `-S`, `--skip-preflight` | `SKIP_PREFLIGHT` |
+| `-L`, `--log-level` | `GITMUX_LOG_LEVEL` |
+| `-F`, `--filter-backend` | `GITMUX_FILTER_BACKEND` |
 | `--author-name` | `GITMUX_AUTHOR_NAME` |
 | `--author-email` | `GITMUX_AUTHOR_EMAIL` |
 | `--committer-name` | `GITMUX_COMMITTER_NAME` |
 | `--committer-email` | `GITMUX_COMMITTER_EMAIL` |
 | `--coauthor-action` | `GITMUX_COAUTHOR_ACTION` |
-| `--filter-backend` | `GITMUX_FILTER_BACKEND` |
-| `--log-level` | `GITMUX_LOG_LEVEL` |
+
+Some knobs have no CLI flag and are set only via the environment:
+
+| Environment Variable | Default | Description |
+|----------------------|---------|-------------|
+| `PRESERVE_COMMITTER_DATES` | `true` | Preserve original authorship dates as committer dates on rebase (see [Rebase Options](#rebase-options)) |
+| `GH_HOST` | `github.com` | GitHub host used for `gh` operations |
 
 CLI options take precedence over environment variables.


### PR DESCRIPTION
Corrects the README and the gitmux.com docs site against the actual behavior of `gitmux.sh`, from a documentation audit (two review passes, every claim cross-checked against the source). Follows #59 (which flipped the default destination branch to `main`), so the `-b` default here reads `main`.

## Fixes
- **README / index** — list the real dependencies (`jq` is hard-required; `gh` is needed for `-s`/`-c`/`-z`) that Install omitted while every example uses `-s`; qualify the "never direct pushes" pitch (the `-c` bootstrap *does* push directly when creating a repo).
- **usage** — `-b` default is `main` (was "main/master"); add the missing `-V`/`--version` row; complete the Environment Variables table (all CLI-mapped vars + the env-only `GH_HOST` and `PRESERVE_COMMITTER_DATES`); document rename-lineage `-m` (distinct sources → same dest); add short flag aliases; note `-o` is mutually exclusive with `-X`.
- **filter-backend** — fix the "only affects performance" claim: a committer identity different from the author is only supported by `filter-branch` (`filter-repo` applies the same to both and warns).
- **rebase-strategies** — document committer-date preservation (`PRESERVE_COMMITTER_DATES`); note `-o` **replaces** the default rebase options.
- **faq** — add "why are my commit dates all today?" and "reassemble a renamed file's history?" entries; fix the PR branch-name pattern (includes the `-rebase-strategy-<strategy>` suffix).

Docs auto-deploy to gitmux.com from `/docs` on merge. No code changed.
